### PR TITLE
Add Zsh benchmark automation via GitHub Actions and benchmark script

### DIFF
--- a/.github/scripts/zsh-benchmark.sh
+++ b/.github/scripts/zsh-benchmark.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -e
+
+ZSH_BENCH_REPO="https://github.com/romkatv/zsh-bench"
+ZSH_BENCH_DIR="${ZSH_BENCH_DIR:-${RUNNER_TEMP:-${TMPDIR:-/tmp/}}zsh-bench}"
+BENCHMARK_RESULT="${BENCHMARK_RESULT:-/dev/stdout}"
+
+# Ensure git is installed
+if ! command -v git &>/dev/null; then
+    echo "Error: git is not installed." >&2
+    exit 1
+fi
+
+# Setup cleanup to remove temporary files, excluding benchmark result
+cleanup() {
+    echo "Cleaning up temporary files..."
+    rm -rf "$ZSH_BENCH_DIR"
+}
+trap cleanup EXIT
+
+# Start message
+echo "Starting Zsh benchmark..."
+echo "Temporary directory for zsh-bench: $ZSH_BENCH_DIR"
+
+# Clone zsh-bench repository if it doesn't exist
+if [ ! -d "$ZSH_BENCH_DIR" ]; then
+    echo "Cloning zsh-bench repository from $ZSH_BENCH_REPO..."
+    git clone "$ZSH_BENCH_REPO" "$ZSH_BENCH_DIR" &>/dev/null || {
+        echo "Error: Failed to clone $ZSH_BENCH_REPO" >&2
+        exit 1
+    }
+    echo "Repository cloned successfully."
+else
+    echo "zsh-bench repository already exists in $ZSH_BENCH_DIR. Skipping clone."
+fi
+
+# Run zsh-bench and process results
+echo "Running zsh-bench..."
+"$ZSH_BENCH_DIR/zsh-bench" |
+    awk '
+BEGIN {
+    print "["   # Start the JSON array
+    is_first = 1  # Flag to track the first record
+}
+{
+    split($0, arr, "=")          # Split the line by "="
+    metric_name = arr[1]         # The first part is the metric name
+    metric_value = arr[2]        # The second part is the metric value
+
+    # Split the metric name by "_" to extract the unit
+    n = split(metric_name, name_parts, "_")
+    unit = name_parts[n]         # The last part of the metric name is the unit
+
+    # Filter to include only metrics with unit "ms"
+    if (unit == "ms") {
+        if (!is_first) {
+            printf ",\n"  # Add a comma before every record except the first
+        }
+        is_first = 0      # Reset the first record flag
+        printf "  {\n    \"name\": \"%s\",\n    \"unit\": \"%s\",\n    \"value\": %s\n  }", metric_name, unit, metric_value
+    }
+}
+END {
+    print "\n]"   # End the JSON array
+}
+' >"$BENCHMARK_RESULT"
+
+echo "Benchmark completed successfully."
+if [[ "$BENCHMARK_RESULT" != "/dev/stdout" ]]; then
+    echo "Results saved to: $BENCHMARK_RESULT"
+fi

--- a/.github/scripts/zsh-benchmark.sh
+++ b/.github/scripts/zsh-benchmark.sh
@@ -2,7 +2,7 @@
 set -e
 
 ZSH_BENCH_REPO="https://github.com/romkatv/zsh-bench"
-ZSH_BENCH_DIR="${ZSH_BENCH_DIR:-${RUNNER_TEMP:-${TMPDIR:-/tmp/}}zsh-bench}"
+ZSH_BENCH_DIR="${ZSH_BENCH_DIR:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/zsh-bench}"
 BENCHMARK_RESULT="${BENCHMARK_RESULT:-/dev/stdout}"
 
 # Ensure git is installed

--- a/.github/workflows/zsh-benchmark.yml
+++ b/.github/workflows/zsh-benchmark.yml
@@ -21,13 +21,6 @@ jobs:
         run: |
           echo ". $GITHUB_WORKSPACE/.zshenv" > ~/.zshenv
 
-      - name: Set up dependencies
-        run: |
-          if [[ "$(uname)" == "Linux" ]]; then
-            sudo apt update
-            sudo apt install -y zsh git
-          fi
-
       - name: Run Zsh Benchmark
         run: bash ./.github/scripts/zsh-benchmark.sh
 
@@ -38,6 +31,6 @@ jobs:
           tool: "customSmallerIsBetter"
           output-file-path: "$BENCHMARK_RESULT"
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          save-data: ${{ github.event_name == 'push' }}
+          auto-push: ${{ github.event_name == 'push' }}
           comment-on-alert: ${{ github.event_name == 'pull_request' }}
           fail-on-alert: false

--- a/.github/workflows/zsh-benchmark.yml
+++ b/.github/workflows/zsh-benchmark.yml
@@ -16,7 +16,13 @@ jobs:
 
       - name: Set Zsh environment (ZDOTDIR)
         run: |
-          echo ". $GITHUB_WORKSPACE/.zshenv" > ~/.zshenv
+          ZDOTDIR=~/.config/zsh
+          ln -s $GITHUB_WORKSPACE $ZDOTDIR
+          echo ". $ZDOTDIR/.zshenv" > ~/.zshenv
+
+      - name: Check Zsh environment
+        run: |
+          echo ""
 
       - name: Run Zsh Benchmark
         run: bash ./.github/scripts/zsh-benchmark.sh
@@ -26,7 +32,7 @@ jobs:
       - name: Upload Benchmark Results
         uses: benchmark-action/github-action-benchmark@v1
         with:
-          name: "$RUNNER_OS"
+          name: "$${{ runner.os }}"
           tool: "customSmallerIsBetter"
           output-file-path: benchmark-result.json
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/zsh-benchmark.yml
+++ b/.github/workflows/zsh-benchmark.yml
@@ -1,0 +1,43 @@
+name: Zsh Benchmark
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+env:
+  BENCHMARK_RESULT: ./benchmark-result.json
+
+jobs:
+  benchmark:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set Zsh environment (ZDOTDIR)
+        run: |
+          echo ". $GITHUB_WORKSPACE/.zshenv" > ~/.zshenv
+
+      - name: Set up dependencies
+        run: |
+          if [[ "$(uname)" == "Linux" ]]; then
+            sudo apt update
+            sudo apt install -y zsh git
+          fi
+
+      - name: Run Zsh Benchmark
+        run: bash ./scripts/zsh-benchmark.sh
+
+      - name: Upload Benchmark Results
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: "$RUNNER_OS"
+          tool: "customSmallerIsBetter"
+          output-file-path: "$BENCHMARK_RESULT"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          save-data: ${{ github.event_name == 'push' }}
+          comment-on-alert: ${{ github.event_name == 'pull_request' }}
+          fail-on-alert: false

--- a/.github/workflows/zsh-benchmark.yml
+++ b/.github/workflows/zsh-benchmark.yml
@@ -29,7 +29,7 @@ jobs:
           fi
 
       - name: Run Zsh Benchmark
-        run: bash ./scripts/zsh-benchmark.sh
+        run: bash ./.github/scripts/zsh-benchmark.sh
 
       - name: Upload Benchmark Results
         uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/zsh-benchmark.yml
+++ b/.github/workflows/zsh-benchmark.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Upload Benchmark Results
         uses: benchmark-action/github-action-benchmark@v1
         with:
-          name: "$${{ runner.os }}"
+          name: "${{ runner.os }}"
           tool: "customSmallerIsBetter"
           output-file-path: benchmark-result.json
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/zsh-benchmark.yml
+++ b/.github/workflows/zsh-benchmark.yml
@@ -6,9 +6,6 @@ on:
     branches:
       - main
 
-env:
-  BENCHMARK_RESULT: ./benchmark-result.json
-
 jobs:
   benchmark:
     runs-on: macos-latest
@@ -23,13 +20,15 @@ jobs:
 
       - name: Run Zsh Benchmark
         run: bash ./.github/scripts/zsh-benchmark.sh
+        env:
+          BENCHMARK_RESULT: benchmark-result.json
 
       - name: Upload Benchmark Results
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: "$RUNNER_OS"
           tool: "customSmallerIsBetter"
-          output-file-path: "$BENCHMARK_RESULT"
+          output-file-path: benchmark-result.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: ${{ github.event_name == 'push' }}
           comment-on-alert: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
- Introduced a new script `zsh-benchmark.sh` in `.github/scripts` to automate the benchmarking of Zsh shell performance. This script sets up an environment, ensures required dependencies, clones the zsh-bench repository, runs benchmarks, and processes results to a JSON format focusing on metrics in milliseconds.
- Created a GitHub Actions workflow `zsh-benchmark.yml` under `.github/workflows` which triggers on pull requests and pushes to the main branch. It configures the environment and dependencies, runs the benchmark script, and utilizes the `github-action-benchmark` to process and store benchmark results. The workflow is designed to run specifically on macOS latest runners.
- The benchmark results are saved to `benchmark-result.json` within the workflow and uploaded as part of the GitHub Action process. The results are only saved when the trigger is a push event, and comments on the result metrics are made during pull request events.
- This setup enhances the project's continuous integration process by providing detailed performance metrics of the Zsh shell, aiding in the identification of potential performance regressions or improvements.